### PR TITLE
비밀번호 변경 리팩토링

### DIFF
--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -4,8 +4,15 @@ import { AuthModule } from './auth/auth.module';
 import { typeORMConfig } from './config/typeorm.config';
 import { BookModule } from './book/book.module';
 import { AdminModule } from './admin/admin.module';
+import { LikeModule } from './like/like.module';
 
 @Module({
-  imports: [TypeOrmModule.forRoot(typeORMConfig), AuthModule, BookModule, AdminModule],
+  imports: [
+    TypeOrmModule.forRoot(typeORMConfig),
+    AuthModule,
+    BookModule,
+    AdminModule,
+    LikeModule,
+  ],
 })
 export class AppModule {}

--- a/server/src/auth/auth.controller.ts
+++ b/server/src/auth/auth.controller.ts
@@ -38,7 +38,7 @@ export class AuthController {
 
   @Put('/changepw')
   @UseGuards(AuthGuard())
-  changePassword(@Body() { id, password }: { id: number; password: string }) {
-    return this.authService.changePassword(id, password);
+  changePassword(@GetUser() user: User, @Body('password') password: string) {
+    return this.authService.changePassword(user, password);
   }
 }

--- a/server/src/auth/auth.service.ts
+++ b/server/src/auth/auth.service.ts
@@ -29,7 +29,8 @@ export class AuthService {
     const user = await this.userRepository.findOneBy({ email });
 
     if (user && (await bcrypt.compare(password, user.password))) {
-      const payload: JwtPayload = { id: user.id };
+      const payload: JwtPayload = { id: user.id, role: user.role };
+
       const accessToken = await this.jwtService.sign(payload);
       return { accessToken };
     } else {
@@ -51,7 +52,7 @@ export class AuthService {
     }
   }
 
-  async changePassword(id: number, password: string) {
+  async changePassword({ id }: User, password: string) {
     const foundUser = await this.userRepository.findOneBy({ id });
 
     if (foundUser) {


### PR DESCRIPTION
어떤 api를 사용할때 user의 유효성을 검사를 하기위해 로그인시 토큰 생성할때 payload값에 user.id 와 user.role 값을 넣어줬다.
1. Role값을 통해 admin인지 아닌지 확인용도
2. id 를 통해 다양한 api 접근하기 위한 용도

하지만 이런 유효성 검사에 2가지 방법이 있는데 무엇을 사용해야하는지 고민이 되었다.

1. JwtAuthGuard를 사용하는 방법
@UseGuards(JwtAuthGuard) 를 데코레이트 해주면 request에서 사용자 정보를 가져올 수 있다. 하지만 내가 정의해둔 user.entity에 의해 user 정보를 가져오기때문에 쓸데없는 비밀번호나 개인정보를 가져올 수 있다.

GPT 답변
- 장점:

            NestJS에서 제공하는 JwtAuthGuard는 Passport 라이브러리를 사용하여 토큰의 유효성을 검사하므로, 일반적으로 안전한 방법입니다.
            코드가 간결하고 유지보수가 쉽습니다.
            인증 실패 시 자동으로 예외가 발생하여 요청이 거부되므로 간편합니다.
- 단점:

            Payload의 일부만 가져오기 위해서는 추가적인 작업이 필요할 수 있습니다.
            자동으로 유효성 검사를 수행하기 때문에 불필요한 오버헤드가 발생할 수 있습니다.

2. JwtService 의 decoded 메서드 사용법 
내가 원하는 payload값만 가져올 수 있다는 장점이 있다. 

GPT 답변
- 장점:

            직접 토큰을 decode하고 원하는 payload를 추출할 수 있어, 필요한 정보만 가져올 수 있습니다.
            더 세밀한 컨트롤이 가능합니다.
- 단점:

            직접 유효성 검사를 수행해야 하므로, 코드가 복잡해질 수 있습니다.
            예외 처리 등을 개발자가 수동으로 관리해야 합니다.
            
            
일반적으로는 JwtAuthGuard를 사용하는 것이 더 편리하며, NestJS의 Passport 라이브러리가 안전한 방식으로 인증을 처리하도록 도와주기 때문에 이를 활용하는 것이 권장된다고 하여 일단 JwtAuthGuard를 사용하였다.